### PR TITLE
Remove standard console logging and use zerolog

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	gremcos "github.com/supplyon/gremcos"
 
 	"github.com/imeplusplus/dont-panic-api/app/handler"
@@ -31,7 +32,7 @@ func (app *App) Initialize() {
 	fmt.Println(username)
 	fmt.Println(password)
 
-	app.Logger = zerolog.New(os.Stdout).Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: zerolog.TimeFieldFormat}).With().Timestamp().Logger()
+	app.Logger = log.Logger
 	app.Cosmos, err = gremcos.New(host,
 		gremcos.WithAuth(username, password),
 		gremcos.WithLogger(app.Logger),
@@ -41,7 +42,7 @@ func (app *App) Initialize() {
 	)
 
 	if err != nil {
-		fmt.Println("Could not connect database")
+		log.Error().Err(err).Msg("Could not connect to server")
 	}
 
 	app.Router = mux.NewRouter()
@@ -87,5 +88,5 @@ func (app *App) handleRequest(handler RequestHandlerFunction) http.HandlerFunc {
 
 // Run the app on it's router
 func (app *App) Run(host string) {
-	fmt.Println(http.ListenAndServe(host, app.Router))
+	log.Info().Msg(http.ListenAndServe(host, app.Router).Error())
 }

--- a/app/dbOperations/subjects.go
+++ b/app/dbOperations/subjects.go
@@ -1,9 +1,6 @@
 package dbOperations
 
 import (
-	"fmt"
-
-	"github.com/rs/zerolog/log"
 	gremcos "github.com/supplyon/gremcos"
 	"github.com/supplyon/gremcos/api"
 	"github.com/supplyon/gremcos/interfaces"
@@ -19,7 +16,6 @@ func GetSubjects(cosmos gremcos.Cosmos) ([]storageModel.Subject, error) {
 	res, err := cosmos.ExecuteQuery(query)
 
 	if err != nil {
-		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return nil, err
 	}
 
@@ -41,7 +37,6 @@ func GetSubjectByName(cosmos gremcos.Cosmos, name string) (storageModel.Subject,
 
 	res, err := cosmos.ExecuteQuery(query)
 	if err != nil {
-		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return subject, err
 	}
 
@@ -52,20 +47,17 @@ func CreateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject) (storage
 	_, err := GetSubjectByName(cosmos, subject.Name)
 
 	if err == nil {
-		err := logger.ErrorResourceAlreadyExists{ResourceName: subject.Name}.Error()
-		log.Error().Err(err).Msg(fmt.Sprintf("There is already a subject with name %s in the database", subject.Name))
+		err := logger.ErrorResourceAlreadyExists{ResourceName: subject.Name}
 		return storageModel.Subject{}, err
 	}
 
 	g := api.NewGraph("g")
 
 	query := g.AddV("subject").Property("partitionKey", "subject")
-
 	query = addVertexProperties(query, subject)
 
 	res, err := cosmos.ExecuteQuery(query)
 	if err != nil {
-		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return storageModel.Subject{}, err
 	}
 
@@ -74,10 +66,7 @@ func CreateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject) (storage
 
 func UpdateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject, name string) (storageModel.Subject, error) {
 	oldSubject, err := GetSubjectByName(cosmos, name)
-
 	if err != nil {
-		err := logger.ErrorResourceNotFound{ResourceName: name}.Error()
-		log.Error().Err(err).Msg(fmt.Sprintf("Couldn't find subject with name %s in the database", name))
 		return storageModel.Subject{}, err
 	}
 
@@ -86,7 +75,6 @@ func UpdateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject, name str
 
 	res, err := cosmos.ExecuteQuery(query)
 	if err != nil {
-		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return storageModel.Subject{}, err
 	}
 
@@ -125,8 +113,7 @@ func getSubjectFromResponse(res []interfaces.Response) (storageModel.Subject, er
 	vertices, _ := response.ToVertices()
 
 	if len(vertices) == 0 {
-		err := logger.ErrorResourceNotFound{ResourceName: "response"}.Error()
-		log.Error().Err(err).Msg("")
+		err := logger.ErrorNoVerticesInQuery{}
 		return subject, err
 	}
 

--- a/app/dbOperations/subjects.go
+++ b/app/dbOperations/subjects.go
@@ -1,13 +1,14 @@
 package dbOperations
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	gremcos "github.com/supplyon/gremcos"
 	"github.com/supplyon/gremcos/api"
 	"github.com/supplyon/gremcos/interfaces"
 
+	"github.com/imeplusplus/dont-panic-api/app/logger"
 	storageModel "github.com/imeplusplus/dont-panic-api/app/model/storage"
 )
 
@@ -18,8 +19,7 @@ func GetSubjects(cosmos gremcos.Cosmos) ([]storageModel.Subject, error) {
 	res, err := cosmos.ExecuteQuery(query)
 
 	if err != nil {
-		fmt.Println("Failed to execute a gremlin command " + query.String())
-		//logger.Error().Err(err).Msg("Failed to execute a gremlin command")
+		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return nil, err
 	}
 
@@ -41,8 +41,7 @@ func GetSubjectByName(cosmos gremcos.Cosmos, name string) (storageModel.Subject,
 
 	res, err := cosmos.ExecuteQuery(query)
 	if err != nil {
-		fmt.Println("Failed to execute a gremlin command " + query.String())
-		//logger.Error().Err(err).Msg("Failed to execute a gremlin command")
+		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return subject, err
 	}
 
@@ -53,7 +52,9 @@ func CreateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject) (storage
 	_, err := GetSubjectByName(cosmos, subject.Name)
 
 	if err == nil {
-		return storageModel.Subject{}, errors.New("There is already a subject with name " + subject.Name)
+		err := logger.ErrorResourceAlreadyExists{ResourceName: subject.Name}.Error()
+		log.Error().Err(err).Msg(fmt.Sprintf("There is already a subject with name %s in the database", subject.Name))
+		return storageModel.Subject{}, err
 	}
 
 	g := api.NewGraph("g")
@@ -64,8 +65,7 @@ func CreateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject) (storage
 
 	res, err := cosmos.ExecuteQuery(query)
 	if err != nil {
-		fmt.Println("Failed to execute a gremlin command " + query.String())
-		// logger.Error().Err(err).Msg("Failed to execute gremlin command")
+		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return storageModel.Subject{}, err
 	}
 
@@ -76,7 +76,9 @@ func UpdateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject, name str
 	oldSubject, err := GetSubjectByName(cosmos, name)
 
 	if err != nil {
-		return storageModel.Subject{}, errors.New("There is no subject with name " + oldSubject.Name)
+		err := logger.ErrorResourceNotFound{ResourceName: name}.Error()
+		log.Error().Err(err).Msg(fmt.Sprintf("Couldn't find subject with name %s in the database", name))
+		return storageModel.Subject{}, err
 	}
 
 	g := api.NewGraph("g")
@@ -84,8 +86,7 @@ func UpdateSubject(cosmos gremcos.Cosmos, subject storageModel.Subject, name str
 
 	res, err := cosmos.ExecuteQuery(query)
 	if err != nil {
-		fmt.Println("Failed to execute a gremlin command " + query.String())
-		//logger.Error().Err(err).Msg("Failed to execute a gremlin command")
+		log.Error().Err(err).Msg(fmt.Sprintf("Failed to execute the gremlin command: %v", query))
 		return storageModel.Subject{}, err
 	}
 
@@ -124,7 +125,9 @@ func getSubjectFromResponse(res []interfaces.Response) (storageModel.Subject, er
 	vertices, _ := response.ToVertices()
 
 	if len(vertices) == 0 {
-		return subject, errors.New("there is no vertex in the response")
+		err := logger.ErrorResourceNotFound{ResourceName: "response"}.Error()
+		log.Error().Err(err).Msg("")
+		return subject, err
 	}
 
 	subject = vertexToSubject(vertices[0])

--- a/app/handler/subjects.go
+++ b/app/handler/subjects.go
@@ -2,21 +2,23 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
 	gremcos "github.com/supplyon/gremcos"
 
 	"github.com/imeplusplus/dont-panic-api/app/dbOperations"
+	"github.com/imeplusplus/dont-panic-api/app/logger"
 	apiModel "github.com/imeplusplus/dont-panic-api/app/model/api"
+	storageModel "github.com/imeplusplus/dont-panic-api/app/model/storage"
 )
 
 func GetSubjects(cosmos gremcos.Cosmos, w http.ResponseWriter, _ *http.Request) {
 	res, err := dbOperations.GetSubjects(cosmos)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -25,9 +27,13 @@ func GetSubjects(cosmos gremcos.Cosmos, w http.ResponseWriter, _ *http.Request) 
 	err = json.NewEncoder(w).Encode(res)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+	msg := logger.ResourceRead{
+		Resource: storageModel.PrettyPrint(res),
+	}
+	log.Info().Msg(msg.Info())
 }
 
 func GetSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request) {
@@ -36,7 +42,7 @@ func GetSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request) {
 	res, err := dbOperations.GetSubjectByName(cosmos, vars["name"])
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -45,26 +51,32 @@ func GetSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request) {
 	err = json.NewEncoder(w).Encode(res)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+
+	msg := logger.ResourceRead{
+		Resource: storageModel.PrettyPrint(res),
+	}
+	log.Info().Msg(msg.Info())
 }
 
 func UpdateSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+	name := vars["name"]
+	oldSubject, err := dbOperations.GetSubjectByName(cosmos, name)
 
 	subject := apiModel.Subject{}
-	err := json.NewDecoder(r.Body).Decode(&subject)
-
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&subject); err != nil {
+		log.Error().Stack().Err(err).Msg("Couldn't parse request body into apiModel.Subject")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	res, err := dbOperations.UpdateSubject(cosmos, subject, vars["name"])
+	res, err := dbOperations.UpdateSubject(cosmos, subject, name)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -74,30 +86,48 @@ func UpdateSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request
 	err = json.NewEncoder(w).Encode(res)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("Couldn't create response body with created subject")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+	msg := logger.ResourceUpdated{
+		PastResource: storageModel.PrettyPrint(oldSubject),
+		NewResource:  storageModel.PrettyPrint(res),
+	}
+	log.Info().Msg(msg.Info())
 }
 
 func DeleteSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-
-	err := dbOperations.DeleteSubject(cosmos, vars["name"])
+	name := vars["name"]
+	subject, err := dbOperations.GetSubjectByName(cosmos, name)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	err = dbOperations.DeleteSubject(cosmos, name)
+
+	if err != nil {
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
+
+	msg := logger.ResourceCreated{
+		Resource: storageModel.PrettyPrint(subject),
+	}
+	log.Info().Msg(msg.Info())
 }
 
 func CreateSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request) {
 	subject := apiModel.Subject{}
-	var err error
-	if err = json.NewDecoder(r.Body).Decode(&subject); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&subject); err != nil {
+		log.Error().Stack().Err(err).Msg("Couldn't parse request body into apiModel.Subject")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -105,7 +135,7 @@ func CreateSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request
 	res, err := dbOperations.CreateSubject(cosmos, subject)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -115,7 +145,12 @@ func CreateSubject(cosmos gremcos.Cosmos, w http.ResponseWriter, r *http.Request
 	err = json.NewEncoder(w).Encode(res)
 
 	if err != nil {
-		fmt.Println(err)
+		log.Error().Stack().Err(err).Msg("Couldn't create response body with created subject")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+
+	msg := logger.ResourceCreated{
+		Resource: storageModel.PrettyPrint(res),
+	}
+	log.Info().Msg(msg.Info())
 }

--- a/app/logger/errors.go
+++ b/app/logger/errors.go
@@ -5,23 +5,23 @@ import (
 )
 
 var (
-	errorResourceAlreadyExistsMessage = LogEvent{1, "Resource %s already exists"}
-	errorResourceNotFoundMessage      = LogEvent{2, "Resource %s not found"}
-	errorNoVertexInResourceMessage    = LogEvent{3, "There is no vertex in resource %s"}
+	errorResourceAlreadyExistsMessage = LogEvent{1, "resource %s already exists"}
+	errorResourceNotFoundMessage      = LogEvent{2, "resource %s not found"}
+	errorNoVerticesInQueryMessage     = LogEvent{3, "the Gremlin Query did not return any vertices"}
 )
 
 type ErrorResourceAlreadyExists struct{ ResourceName string }
 type ErrorResourceNotFound struct{ ResourceName string }
-type ErrorNoVertexInResource struct{ ResourceName string }
+type ErrorNoVerticesInQuery struct{}
 
-func (e ErrorResourceAlreadyExists) Error() error {
-	return fmt.Errorf(errorResourceAlreadyExistsMessage.message, e.ResourceName)
+func (e ErrorResourceAlreadyExists) Error() string {
+	return fmt.Sprintf(errorResourceAlreadyExistsMessage.message, e.ResourceName)
 }
 
-func (e ErrorResourceNotFound) Error() error {
-	return fmt.Errorf(errorResourceNotFoundMessage.message, e.ResourceName)
+func (e ErrorResourceNotFound) Error() string {
+	return fmt.Sprintf(errorResourceNotFoundMessage.message, e.ResourceName)
 }
 
-func (e ErrorNoVertexInResource) Error() error {
-	return fmt.Errorf(errorNoVertexInResourceMessage.message, e.ResourceName)
+func (e ErrorNoVerticesInQuery) Error() string {
+	return fmt.Sprintf(errorNoVerticesInQueryMessage.message)
 }

--- a/app/logger/errors.go
+++ b/app/logger/errors.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"fmt"
+)
+
+var (
+	errorResourceAlreadyExistsMessage = LogEvent{1, "Resource %s already exists"}
+	errorResourceNotFoundMessage      = LogEvent{2, "Resource %s not found"}
+	errorNoVertexInResourceMessage    = LogEvent{3, "There is no vertex in resource %s"}
+)
+
+type ErrorResourceAlreadyExists struct{ ResourceName string }
+type ErrorResourceNotFound struct{ ResourceName string }
+type ErrorNoVertexInResource struct{ ResourceName string }
+
+func (e ErrorResourceAlreadyExists) Error() error {
+	return fmt.Errorf(errorResourceAlreadyExistsMessage.message, e.ResourceName)
+}
+
+func (e ErrorResourceNotFound) Error() error {
+	return fmt.Errorf(errorResourceNotFoundMessage.message, e.ResourceName)
+}
+
+func (e ErrorNoVertexInResource) Error() error {
+	return fmt.Errorf(errorNoVertexInResourceMessage.message, e.ResourceName)
+}

--- a/app/logger/logger.go
+++ b/app/logger/logger.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/rs/zerolog"
@@ -14,38 +13,7 @@ type LogEvent struct {
 	message string
 }
 
-var (
-	resourceCreatedMessage = LogEvent{1001, "Resource created.\nContent:\n%s"}
-	resourceUpdatedMessage = LogEvent{1002, "Resource updated.\nBefore:\n%s\nAfter:\n%s"}
-	resourceReadMessage    = LogEvent{1003, "Resource read.\nContent:\n%s"}
-	resourceDeletedMessage = LogEvent{1004, "Resource %s deleted."}
-)
-
-type ResourceCreated struct{ Resource string }
-type ResourceUpdated struct {
-	PastResource string
-	NewResource  string
-}
-type ResourceRead struct{ Resource string }
-type ResourceDeleted struct{ Resource string }
-
 func init() {
 	log.Logger = zerolog.New(os.Stdout).Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: zerolog.TimeFieldFormat}).With().Timestamp().Logger()
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
-}
-
-func (e ResourceCreated) Info() string {
-	return fmt.Sprintf(resourceCreatedMessage.message, e.Resource)
-}
-
-func (e ResourceUpdated) Info() string {
-	return fmt.Sprintf(resourceUpdatedMessage.message, e.PastResource, e.NewResource)
-}
-
-func (e ResourceRead) Info() string {
-	return fmt.Sprintf(resourceReadMessage.message, e.Resource)
-}
-
-func (e ResourceDeleted) Info() string {
-	return fmt.Sprintf(resourceReadMessage.message, e.Resource)
 }

--- a/app/logger/logger.go
+++ b/app/logger/logger.go
@@ -1,0 +1,51 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog/pkgerrors"
+)
+
+type LogEvent struct {
+	id      int
+	message string
+}
+
+var (
+	resourceCreatedMessage = LogEvent{1001, "Resource created.\nContent:\n%s"}
+	resourceUpdatedMessage = LogEvent{1002, "Resource updated.\nBefore:\n%s\nAfter:\n%s"}
+	resourceReadMessage    = LogEvent{1003, "Resource read.\nContent:\n%s"}
+	resourceDeletedMessage = LogEvent{1004, "Resource %s deleted."}
+)
+
+type ResourceCreated struct{ Resource string }
+type ResourceUpdated struct {
+	PastResource string
+	NewResource  string
+}
+type ResourceRead struct{ Resource string }
+type ResourceDeleted struct{ Resource string }
+
+func init() {
+	log.Logger = zerolog.New(os.Stdout).Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: zerolog.TimeFieldFormat}).With().Timestamp().Logger()
+	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
+}
+
+func (e ResourceCreated) Info() string {
+	return fmt.Sprintf(resourceCreatedMessage.message, e.Resource)
+}
+
+func (e ResourceUpdated) Info() string {
+	return fmt.Sprintf(resourceUpdatedMessage.message, e.PastResource, e.NewResource)
+}
+
+func (e ResourceRead) Info() string {
+	return fmt.Sprintf(resourceReadMessage.message, e.Resource)
+}
+
+func (e ResourceDeleted) Info() string {
+	return fmt.Sprintf(resourceReadMessage.message, e.Resource)
+}

--- a/app/logger/messages.go
+++ b/app/logger/messages.go
@@ -1,0 +1,60 @@
+package logger
+
+import (
+	"fmt"
+)
+
+var (
+	resourceCreatedMessage             = LogEvent{1001, "Resource %s created.\nContent:\n%s"}
+	resourceUpdatedMessage             = LogEvent{1002, "Resource %s updated.\nNew Content:\n%s"}
+	resourceReadMessage                = LogEvent{1003, "Resource %s read.\nContent:\n%s"}
+	resourceDeletedMessage             = LogEvent{1004, "Resource %s deleted.\n"}
+	failedToDecodeJSONMessage          = LogEvent{1005, "Failed to parse JSON into %s.\n"}
+	failedToEncodeJSONMessage          = LogEvent{1006, "Failed to encode %s into JSON format.\n"}
+	failedToExecuteGremlinQueryMessage = LogEvent{1007, "Failed to execute Gremlin query.\n"}
+)
+
+type ResourceCreated struct {
+	ResourceName    string
+	ResourceContent string
+}
+type ResourceUpdated struct {
+	ResourceName    string
+	ResourceContent string
+}
+type ResourceRead struct {
+	ResourceName    string
+	ResourceContent string
+}
+type ResourceDeleted struct{ ResourceName string }
+type FailedToDecodeJSON struct{ Resource string }
+type FailedToEncodeJSON struct{ Resource string }
+type FailedToExecuteGremlinQuery struct{}
+
+func (e ResourceCreated) Info() string {
+	return fmt.Sprintf(resourceCreatedMessage.message, e.ResourceName, e.ResourceContent)
+}
+
+func (e ResourceUpdated) Info() string {
+	return fmt.Sprintf(resourceUpdatedMessage.message, e.ResourceName, e.ResourceContent)
+}
+
+func (e ResourceRead) Info() string {
+	return fmt.Sprintf(resourceReadMessage.message, e.ResourceName, e.ResourceContent)
+}
+
+func (e ResourceDeleted) Info() string {
+	return fmt.Sprintf(resourceDeletedMessage.message, e.ResourceName)
+}
+
+func (e FailedToDecodeJSON) Info() string {
+	return fmt.Sprintf(failedToDecodeJSONMessage.message, e.Resource)
+}
+
+func (e FailedToEncodeJSON) Info() string {
+	return fmt.Sprintf(failedToEncodeJSONMessage.message, e.Resource)
+}
+
+func (e FailedToExecuteGremlinQuery) Info() string {
+	return fmt.Sprintf(failedToExecuteGremlinQueryMessage.message)
+}

--- a/app/model/api/subject.go
+++ b/app/model/api/subject.go
@@ -1,5 +1,12 @@
 package model
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
 type Subject struct {
 	Id           string   `json:"id"`
 	Name         string   `json:"name"`
@@ -7,4 +14,13 @@ type Subject struct {
 	Difficulty   int      `json:"difficulty"`
 	Category     string   `json:"category"`
 	PartitionKey string   `json:"partitionKey"`
+}
+
+func PrettyPrint(subjects ...interface{}) string {
+	subjectJSON, err := json.MarshalIndent(subjects, "", "  ")
+	if err != nil {
+		log.Error().Stack().Err(err).Msg("Couldn't make resource pretty to print")
+		return fmt.Sprintf("%v", subjects)
+	}
+	return string(subjectJSON)
 }

--- a/app/model/storage/subject.go
+++ b/app/model/storage/subject.go
@@ -1,5 +1,12 @@
 package model
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
 type Subject struct {
 	Id           string   `json:"id"`
 	Name         string   `json:"name"`
@@ -7,4 +14,13 @@ type Subject struct {
 	Difficulty   int      `json:"difficulty"`
 	Category     string   `json:"category"`
 	PartitionKey string   `json:"partitionKey"`
+}
+
+func PrettyPrint(subjects ...interface{}) string {
+	subjectJSON, err := json.MarshalIndent(subjects, "", "  ")
+	if err != nil {
+		log.Error().Stack().Err(err).Msg("Couldn't make resource pretty to print")
+		return fmt.Sprintf("%v", subjects)
+	}
+	return string(subjectJSON)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/gorilla/mux v1.8.0
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/zerolog v1.22.0
 	github.com/supplyon/gremcos v0.1.7
 )


### PR DESCRIPTION
### Changes

This PR expands the zerolog usage in the repository, as it was only being used in the app instance and the general console logging was being made by standard `fmt.Println()` calls.

Now we have extended the `error` interface for some structs that represent typed errors, and created `Info()` functions for typed log messages.

### How can I test it?
- `go build .`
- `./dont-panic-api.exe`
- make some requests in postman and check the logs in the console.

### Examples

- [Example 1](https://user-images.githubusercontent.com/18074747/128094958-1eea9622-0de9-46a9-86a1-e06f409c2045.png)
- [Example 2](https://user-images.githubusercontent.com/18074747/128094960-95d42c7c-ee65-4bd8-bcf0-779dde18b9aa.png)
- [Example 3](https://user-images.githubusercontent.com/18074747/128094963-4bab01a8-95c4-4fd5-b189-6cf2dd11fba3.png)
- [Example 4](https://user-images.githubusercontent.com/18074747/128094964-3b18d3a7-1d55-4973-bb90-9a13796eddf5.png)
- [Example 5](https://user-images.githubusercontent.com/18074747/128094965-622481e0-46f3-47af-a784-a7241694b487.png)
- [Example 6](https://user-images.githubusercontent.com/18074747/128094968-c7939ed6-3a1e-4954-92eb-ad297938e243.png)
- [Example 7](https://user-images.githubusercontent.com/18074747/128094970-da2a45da-22a8-4f3d-9ecd-cf7d38cd2f90.png) 

### TODO

As mentioned with @rebecacalazans, we should implement logging to Azure Portal too. I plan to do that later.